### PR TITLE
App-Buttons disabled until LSL started

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -61,7 +61,6 @@ button:disabled {
 
 .app-buttons {
     margin-top: 20px;
-    cursor: not-allowed;
 }
 
 .row {
@@ -103,7 +102,6 @@ button:disabled {
 
 .lsl-disabled button {
     cursor: not-allowed;
-    pointer-events: none;
 }
 
 button.running {

--- a/static/style.css
+++ b/static/style.css
@@ -61,6 +61,7 @@ button:disabled {
 
 .app-buttons {
     margin-top: 20px;
+    cursor: not-allowed;
 }
 
 .row {
@@ -98,6 +99,11 @@ button:disabled {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     color: white;
     cursor: not-allowed;
+}
+
+.lsl-disabled button {
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 button.running {

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
                 <button id="start_lsl_button" class="lsl-running" disabled>LSL Stream Running</button>
             {% endif %}
         </div>        
-        <div class="app-buttons">
+        <div class="app-buttons {% if not lsl_started %}lsl-disabled{% endif %}">
             <!-- Row 1: ECG, EMG, EOG, EEG -->
             <div class="row">
                 <form action="/run_app" method="POST">


### PR DESCRIPTION
If LSL is not started, all the app buttons will remain disabled until LSL starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced button interaction styles for disabled states.
	- Added visual feedback for buttons when LSL stream is not running.

- **User Experience**
	- Improved UI to clearly indicate when buttons are non-interactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->